### PR TITLE
Support resolving images from local Docker daemon (with `docker://` prefix)

### DIFF
--- a/sbt-jib/src/main/scala/de/gccc/jib/JibPlugin.scala
+++ b/sbt-jib/src/main/scala/de/gccc/jib/JibPlugin.scala
@@ -135,7 +135,8 @@ object JibPlugin extends AutoPlugin {
       )
     },
     Private.sbtConfiguration := {
-      val baseImage = ImageReference.parse(jibBaseImage.value)
+      val rawBaseImage                   = jibBaseImage.value
+      val (isDockerDaemonBase, imageRef) = (rawBaseImage.startsWith("docker://"), rawBaseImage.stripPrefix("docker://"))
 
       new SbtConfiguration(
         sLog.value,
@@ -144,7 +145,7 @@ object JibPlugin extends AutoPlugin {
         (Compile / packageBin / discoveredMainClasses).value,
         jibTarget.value / "internal",
         credentials.value,
-        baseImage,
+        ImageReference.parse(imageRef),
         jibRegistry.value,
         jibOrganization.value,
         jibName.value,
@@ -152,7 +153,8 @@ object JibPlugin extends AutoPlugin {
         jibCustomRepositoryPath.value,
         jibAllowInsecureRegistries.value,
         jibSendCredentialsOverHttp.value,
-        jibTarget.value
+        jibTarget.value,
+        isDockerDaemonBase
       )
 
     },

--- a/sbt-jib/src/main/scala/de/gccc/jib/SbtConfiguration.scala
+++ b/sbt-jib/src/main/scala/de/gccc/jib/SbtConfiguration.scala
@@ -26,7 +26,8 @@ private[jib] class SbtConfiguration(
     customRepositoryPath: Option[String],
     val allowInsecureRegistries: Boolean,
     sendCredentialsOverHttp: Boolean,
-    val target: File
+    val target: File,
+    val isDockerDaemonBase: Boolean = false
 ) {
 
   val USER_AGENT_SUFFIX = "jib-sbt-plugin"

--- a/sbt-jib/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
+++ b/sbt-jib/src/main/scala/de/gccc/jib/SbtDockerBuild.scala
@@ -42,13 +42,18 @@ private[jib] object SbtDockerBuild {
         configuration.USER_AGENT_SUFFIX,
         targetDirectory.toPath
       )
-      val baseImage = JibCommon.baseImageFactory(configuration.baseImageReference)(
-        jibBaseImageCredentialHelper,
-        configuration.credsForHost,
-        configuration.logEvent
-      )
-      val container = Jib
-        .from(baseImage)
+      val jibBuilder =
+        if (configuration.isDockerDaemonBase)
+          Jib.from(DockerDaemonImage.named(configuration.baseImageReference))
+        else
+          Jib.from(
+            JibCommon.baseImageFactory(configuration.baseImageReference)(
+              jibBaseImageCredentialHelper,
+              configuration.credsForHost,
+              configuration.logEvent
+            )
+          )
+      val container = jibBuilder
         .setFileEntriesLayers(configuration.getLayerConfigurations)
         .setUser(user.orNull)
         .setEnvironment(environment.asJava)

--- a/sbt-jib/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
+++ b/sbt-jib/src/main/scala/de/gccc/jib/SbtTarImageBuild.scala
@@ -1,6 +1,6 @@
 package de.gccc.jib
 
-import com.google.cloud.tools.jib.api.{ Containerizer, ImageReference, Jib, TarImage }
+import com.google.cloud.tools.jib.api.{ Containerizer, DockerDaemonImage, ImageReference, Jib, TarImage }
 import com.google.cloud.tools.jib.api.buildplan.{ ImageFormat, Port }
 import de.gccc.jib.JibPlugin.autoImport.JibImageFormat
 import de.gccc.jib.common.JibCommon
@@ -45,13 +45,18 @@ private[jib] object SbtTarImageBuild {
         configuration.USER_AGENT_SUFFIX,
         targetDirectory.toPath
       )
-      val baseImage = JibCommon.baseImageFactory(configuration.baseImageReference)(
-        jibBaseImageCredentialHelper,
-        configuration.credsForHost,
-        configuration.logEvent
-      )
-      val container = Jib
-        .from(baseImage)
+      val jibBuilder =
+        if (configuration.isDockerDaemonBase)
+          Jib.from(DockerDaemonImage.named(configuration.baseImageReference))
+        else
+          Jib.from(
+            JibCommon.baseImageFactory(configuration.baseImageReference)(
+              jibBaseImageCredentialHelper,
+              configuration.credsForHost,
+              configuration.logEvent
+            )
+          )
+      val container = jibBuilder
         .setFileEntriesLayers(configuration.getLayerConfigurations)
         .setEnvironment(environment.asJava)
         .setLabels(labels.asJava)


### PR DESCRIPTION
Like the [Jib plugin for Maven/Gradle](https://github.com/GoogleContainerTools/jib/blob/586b4a6f57f208bb4128aa7286741a23bf9eda7b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java#L538), it enables images to be retrieved from the Docker daemon.

---

### test

Setup base image, 

```console
$ echo -e 'FROM eclipse-temurin:17-jre\nCMD []' | docker build -t dummy-image:latest -
```

and project:

```scala
lazy val jibTest = (project in file("jib-test"))
  .enablePlugins(JibPlugin)
  .settings(
    name := "jib-test",
    jibBaseImage := "docker://dummy-image:latest",
    jibCustomRepositoryPath := Some("jib-test"),
    jibVersion := "latest"
  )
```

<br>

Before:

```console
$ sbt jibTest/jibDockerBuild
...
[error] com.google.cloud.tools.jib.api.InvalidImageReferenceException: Invalid image reference: docker://dummy-image:latest
[error] 	at com.google.cloud.tools.jib.api.ImageReference.parse(ImageReference.java:105)
[error] 	at de.gccc.jib.JibPlugin$.$anonfun$projectSettings$31(JibPlugin.scala:138)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[error] 	at java.base/java.lang.Thread.run(Thread.java:840)
[error] (jibTest / sbtConfiguration) com.google.cloud.tools.jib.api.InvalidImageReferenceException: Invalid image reference: docker://dummy-image:latest
```

After:

```console
$ sbt jibTest/jibDockerBuild
...
[success] image successfully created & uploaded
```
